### PR TITLE
Fix lamba-case error with GHC 8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## GHC syntax highlighter 0.0.3.1
+
+* Fixed the bug when certain extensions such as `-XLambdaCase` were not
+  enabled when the code was compiled with GHC 8.6.
+
 ## GHC syntax highlighter 0.0.3.0
 
 * Compiles with GHC 8.6.

--- a/GHC/SyntaxHighlighter.hs
+++ b/GHC/SyntaxHighlighter.hs
@@ -432,7 +432,9 @@ data ExtBits
   = FfiBit
   | InterruptibleFfiBit
   | CApiFfiBit
+#if !MIN_VERSION_ghc(8,6,0)
   | ParrBit
+#endif
   | ArrowsBit
   | ThBit
   | ThQuotesBit
@@ -468,6 +470,9 @@ data ExtBits
   | TypeApplicationsBit
   | StaticPointersBit
   | NumericUnderscoresBit
+#if MIN_VERSION_ghc(8,6,0)
+  | StarIsTypeBit
+#endif
   deriving Enum
 
 -- | Extension we enable for the best user experience.
@@ -477,7 +482,9 @@ enabledExts =
   [ FfiBit
   , InterruptibleFfiBit
   , CApiFfiBit
+#if !MIN_VERSION_ghc(8,6,0)
   , ParrBit
+#endif
   , ArrowsBit
   , ThBit
   , ThQuotesBit
@@ -505,4 +512,7 @@ enabledExts =
   , TypeApplicationsBit
   , StaticPointersBit
   , NumericUnderscoresBit
+#if MIN_VERSION_ghc(8,6,0)
+  , StarIsTypeBit
+#endif
   ]

--- a/data/LambdaCase.hs
+++ b/data/LambdaCase.hs
@@ -1,0 +1,4 @@
+foo :: Foo -> Maybe Bar
+foo = \case
+  Foo -> Just Bar
+  _   -> Nothing

--- a/tests/GHC/SyntaxHighlighterSpec.hs
+++ b/tests/GHC/SyntaxHighlighterSpec.hs
@@ -14,6 +14,7 @@ spec = describe "tokenizeHaskell" $ do
   it "parses a basic module" (withFile "data/Main.hs" basicModule)
   it "parses a type family" (withFile "data/TypeFamily.hs" typeFamily)
   it "parses an explicit forall" (withFile "data/Forall.hs" explicitForall)
+  it "parses lambda case correctly" (withFile "data/LambdaCase.hs" lambdaCase)
 
 withFile :: FilePath -> [(Token, Text)] -> Expectation
 withFile path toks = do
@@ -158,5 +159,42 @@ explicitForall =
   , (SymbolTok,"=")
   , (SpaceTok," ")
   , (VariableTok,"undefined")
+  , (SpaceTok,"\n")
+  ]
+
+lambdaCase :: [(Token, Text)]
+lambdaCase =
+  [ (VariableTok,"foo")
+  , (SpaceTok," ")
+  , (SymbolTok,"::")
+  , (SpaceTok," ")
+  , (ConstructorTok,"Foo")
+  , (SpaceTok," ")
+  , (SymbolTok,"->")
+  , (SpaceTok," ")
+  , (ConstructorTok,"Maybe")
+  , (SpaceTok," ")
+  , (ConstructorTok,"Bar")
+  , (SpaceTok,"\n")
+  , (VariableTok,"foo")
+  , (SpaceTok," ")
+  , (SymbolTok,"=")
+  , (SpaceTok," ")
+  , (SymbolTok,"\\")
+  , (SymbolTok,"case")
+  , (SpaceTok,"\n  ")
+  , (ConstructorTok,"Foo")
+  , (SpaceTok," ")
+  , (SymbolTok,"->")
+  , (SpaceTok," ")
+  , (ConstructorTok,"Just")
+  , (SpaceTok," ")
+  , (ConstructorTok,"Bar")
+  , (SpaceTok,"\n  ")
+  , (SymbolTok,"_")
+  , (SpaceTok,"   ")
+  , (SymbolTok,"->")
+  , (SpaceTok," ")
+  , (ConstructorTok,"Nothing")
   , (SpaceTok,"\n")
   ]


### PR DESCRIPTION
There appears to be a problem when lambda case doesn't quite work with 8.6.x.