### PR TITLE
Implement handling of file header pragmas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## GHC syntax highlighter 0.0.4.0
+
+* Implemented highlighting of file header pragmas such as `OPTIONS_GHC` and
+  `LANGUAGE`. They are not handled by the GHC lexer, so custom code were
+  added for this purpose.
+
 ## GHC syntax highlighter 0.0.3.1
 
 * Fixed the bug when certain extensions such as `-XLambdaCase` were not

--- a/data/Pragmas.hs
+++ b/data/Pragmas.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-unused-matches #-}
+
+main :: IO ()
+main = return ()

--- a/tests/GHC/SyntaxHighlighterSpec.hs
+++ b/tests/GHC/SyntaxHighlighterSpec.hs
@@ -15,6 +15,7 @@ spec = describe "tokenizeHaskell" $ do
   it "parses a type family" (withFile "data/TypeFamily.hs" typeFamily)
   it "parses an explicit forall" (withFile "data/Forall.hs" explicitForall)
   it "parses lambda case correctly" (withFile "data/LambdaCase.hs" lambdaCase)
+  it "parses file header pragmas correctly" (withFile "data/Pragmas.hs" pragmas)
 
 withFile :: FilePath -> [(Token, Text)] -> Expectation
 withFile path toks = do
@@ -196,5 +197,31 @@ lambdaCase =
   , (SymbolTok,"->")
   , (SpaceTok," ")
   , (ConstructorTok,"Nothing")
+  , (SpaceTok,"\n")
+  ]
+
+pragmas :: [(Token, Text)]
+pragmas =
+  [ (PragmaTok,"{-# LANGUAGE OverloadedStrings #-}")
+  , (SpaceTok,"\n")
+  , (PragmaTok,"{-# OPTIONS_GHC -fno-warn-unused-matches #-}")
+  , (SpaceTok,"\n\n")
+  , (VariableTok,"main")
+  , (SpaceTok," ")
+  , (SymbolTok,"::")
+  , (SpaceTok," ")
+  , (ConstructorTok,"IO")
+  , (SpaceTok," ")
+  , (SymbolTok,"(")
+  , (SymbolTok,")")
+  , (SpaceTok,"\n")
+  , (VariableTok,"main")
+  , (SpaceTok," ")
+  , (SymbolTok,"=")
+  , (SpaceTok," ")
+  , (VariableTok,"return")
+  , (SpaceTok," ")
+  , (SymbolTok,"(")
+  , (SymbolTok,")")
   , (SpaceTok,"\n")
   ]


### PR DESCRIPTION
Close #4.

Implement highlighting of file header pragmas such as `OPTIONS_GHC` and `LANGUAGE`. They are not handled by the GHC lexer, so custom code were added for this purpose.