### PR TITLE
Update to ghc-lib-parser-9.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
   ormolu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: mrkkrp/ormolu-action@v6
   build:
     runs-on: ubuntu-latest
@@ -19,19 +19,19 @@ jobs:
     strategy:
       matrix:
         cabal: ["3.6"]
-        ghc: ["8.10.7", "9.0.2", "9.2.1"]
+        ghc: ["9.0.2", "9.2.4", "9.4.1"]
     env:
       CONFIG: "--enable-tests --enable-benchmarks --flags=dev"
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: haskell/actions/setup@v1.2.9
+      - uses: actions/checkout@v3
+      - uses: haskell/actions/setup@v2
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
       - run: cabal update
       - run: cabal freeze $CONFIG
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ steps.setup-haskell-cabal.outputs.cabal-store }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## GHC syntax highlighter 0.0.9.0
+
+* Uses `ghc-lib-parser-9.4.1.x`.
+
 ## GHC syntax highlighter 0.0.8.0
 
 * Uses `ghc-lib-parser-9.2.1.x`.

--- a/ghc-syntax-highlighter.cabal
+++ b/ghc-syntax-highlighter.cabal
@@ -5,7 +5,7 @@ license:         BSD-3-Clause
 license-file:    LICENSE.md
 maintainer:      Mark Karpov <markkarpov92@gmail.com>
 author:          Mark Karpov <markkarpov92@gmail.com>
-tested-with:     ghc ==8.10.7 ghc ==9.0.2 ghc ==9.2.1
+tested-with:     ghc ==9.0.2 ghc ==9.2.4 ghc ==9.4.1
 homepage:        https://github.com/mrkkrp/ghc-syntax-highlighter
 bug-reports:     https://github.com/mrkkrp/ghc-syntax-highlighter/issues
 synopsis:        Syntax highlighter for Haskell using the lexer of GHC
@@ -31,8 +31,8 @@ library
     default-language: Haskell2010
     build-depends:
         base >=4.13 && <5.0,
-        ghc-lib-parser >=9.2 && <9.3,
-        text >=0.2 && <1.3
+        ghc-lib-parser >=9.4 && <9.5,
+        text >=0.2 && <2.1
 
     if flag(dev)
         ghc-options:
@@ -52,7 +52,7 @@ test-suite tests
     build-depends:
         base >=4.13 && <5.0,
         ghc-syntax-highlighter,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         hspec >=2.0 && <3.0
 
     if flag(dev)


### PR DESCRIPTION
~~ghcup already contains 9.4.1, but cabal does not yet find a build plan, so let's wait for that.~~