### PR TITLE
Update to ghc-lib-parser-9.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         cabal: ["3.8"]
-        ghc: ["9.0.2", "9.2.5", "9.4.4"]
+        ghc: ["9.2.7", "9.4.4", "9.6.1"]
     env:
       CONFIG: "--enable-tests --enable-benchmarks --flags=dev"
     steps:

--- a/GHC/SyntaxHighlighter.hs
+++ b/GHC/SyntaxHighlighter.hs
@@ -326,7 +326,7 @@ classifyToken = \case
   L.ITqvarsym _ -> OperatorTok
   L.ITqconsym _ -> OperatorTok
   L.ITdupipvarid _ -> VariableTok
-  L.ITlabelvarid _ -> VariableTok
+  L.ITlabelvarid {} -> VariableTok
   -- Basic types
   L.ITchar _ _ -> CharTok
   L.ITstring _ _ -> StringTok

--- a/ghc-syntax-highlighter.cabal
+++ b/ghc-syntax-highlighter.cabal
@@ -5,7 +5,7 @@ license:         BSD-3-Clause
 license-file:    LICENSE.md
 maintainer:      Mark Karpov <markkarpov92@gmail.com>
 author:          Mark Karpov <markkarpov92@gmail.com>
-tested-with:     ghc ==9.0.2 ghc ==9.2.5 ghc ==9.4.4
+tested-with:     ghc ==9.2.7 ghc ==9.4.4 ghc ==9.6.1
 homepage:        https://github.com/mrkkrp/ghc-syntax-highlighter
 bug-reports:     https://github.com/mrkkrp/ghc-syntax-highlighter/issues
 synopsis:        Syntax highlighter for Haskell using the lexer of GHC
@@ -30,8 +30,8 @@ library
     exposed-modules:  GHC.SyntaxHighlighter
     default-language: Haskell2010
     build-depends:
-        base >=4.15 && <5.0,
-        ghc-lib-parser >=9.4 && <9.5,
+        base >=4.16 && <5.0,
+        ghc-lib-parser >=9.6 && <9.7,
         text >=0.2 && <2.1
 
     if flag(dev)
@@ -50,7 +50,7 @@ test-suite tests
     other-modules:      GHC.SyntaxHighlighterSpec
     default-language:   Haskell2010
     build-depends:
-        base >=4.15 && <5.0,
+        base >=4.16 && <5.0,
         ghc-syntax-highlighter,
         text >=0.2 && <2.1,
         hspec >=2.0 && <3.0


### PR DESCRIPTION
The GHC API changes are so minimal that keeping support for ghc-lib-parser-9.4 should work fine without any CPP, but I don't directly see a strong reason to do so.